### PR TITLE
1d Gauss example -- returns log(Z)=-0.32, instead of 0?

### DIFF
--- a/Examples/Gauss/Gauss.cpp
+++ b/Examples/Gauss/Gauss.cpp
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2009, 2010, 2011, 2012 Brendon J. Brewer.
+*
+* This file is part of DNest3.
+*
+* DNest3 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* DNest3 is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with DNest3. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "Gauss.h"
+#include "RandomNumberGenerator.h"
+#include "Utils.h"
+#include <cmath>
+
+using namespace std;
+using namespace DNest3;
+
+Gauss::Gauss()
+{
+
+}
+
+void Gauss::fromPrior()
+{
+	u = randomU();
+}
+
+double Gauss::perturb()
+{
+	//cout << "perturbing from " << u << " to ";
+	u += pow(10., 1.5-6*randomU())*randn();
+	//u += randn() / 100;
+	u = mod(u + 100, 1.);
+	//cout << u << endl;
+	return 0.;
+}
+
+double Gauss::logLikelihood() const
+{
+	return -log(0.01 * sqrt(2*M_PI)) - 0.5 * pow((u - 0.654321) / 0.01, 2);
+}
+
+void Gauss::print(std::ostream& out) const
+{
+	out << u << " 1 ";
+}
+
+string Gauss::description() const
+{
+	return string("Gauss");
+}
+

--- a/Examples/Gauss/Gauss.h
+++ b/Examples/Gauss/Gauss.h
@@ -1,0 +1,53 @@
+/*
+* Copyright (c) 2009, 2010, 2011, 2012 Brendon J. Brewer.
+*
+* This file is part of DNest3.
+*
+* DNest3 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* DNest3 is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with DNest3. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _MyModel_
+#define _MyModel_
+
+#include "Model.h"
+#include <vector>
+
+class Gauss:public DNest3::Model
+{
+	private:
+		double u;
+	public:
+		Gauss();
+
+		// Generate the point from the prior
+		void fromPrior();
+
+		// Metropolis-Hastings proposals
+		double perturb();
+
+		// Stretch moves
+		//double perturb_stretch(const MyModel& other, double Z);
+
+		// Likelihood function
+		double logLikelihood() const;
+
+		// Print to stream
+		void print(std::ostream& out) const;
+
+		// Return string with column information
+		std::string description() const;
+};
+
+#endif
+

--- a/Examples/Gauss/Makefile
+++ b/Examples/Gauss/Makefile
@@ -1,0 +1,8 @@
+CFLAGS = -O2 -Wall -Wextra -ansi -pedantic -I ../../include/
+LIBS =  -ldnest3 -lgsl -lgslcblas -lboost_system -lboost_thread -L ../../lib/
+
+default:
+	g++ $(CFLAGS) -c *.cpp
+	g++ -o main *.o $(LIBS)
+	rm -f *.o
+

--- a/Examples/Gauss/OPTIONS
+++ b/Examples/Gauss/OPTIONS
@@ -1,0 +1,11 @@
+# File containing parameters for DNest3
+# Put comments at the top, or at the end of the line.
+1	# Number of particles
+10000	# new level interval
+100000	# save interval
+200	# threadSteps - how many steps each thread should do independently before communication
+50	# maximum number of levels
+10	# Backtracking scale length (lambda in the paper)
+10	# Strength of effect to force histogram to equal push. 0-10 is best. (beta in the paper)
+200	# Maximum number of saves (0 = infinite)
+

--- a/Examples/Gauss/main.cpp
+++ b/Examples/Gauss/main.cpp
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2009, 2010, 2011, 2012 Brendon J. Brewer.
+*
+* This file is part of DNest3.
+*
+* DNest3 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* DNest3 is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with DNest3. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include "Start.h"
+#include "Gauss.h"
+
+using namespace std;
+using namespace DNest3;
+
+int main(int argc, char** argv)
+{
+	#ifndef DNest3_No_Boost
+	MTSampler<Gauss> sampler = setup_mt<Gauss>(argc, argv);
+	#else
+	Sampler<Gauss> sampler = setup<Gauss>(argc, argv);
+	#endif
+
+	sampler.run();
+	return 0;
+}
+

--- a/Examples/Gauss/showresults.py
+++ b/Examples/Gauss/showresults.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2009, 2010, 2011, 2012 Brendon J. Brewer.
+#
+# This file is part of DNest3.
+#
+# DNest3 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# DNest3 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DNest3. If not, see <http://www.gnu.org/licenses/>.
+
+# Import postprocess from two directories up
+# http://stackoverflow.com/a/9806045
+import os
+parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+parentdir = os.path.dirname(parentdir)
+os.sys.path.insert(0, parentdir) 
+import postprocess
+postprocess.postprocess()
+


### PR DESCRIPTION
Dear Brendon,

I would like to use your Diffusive Nested Sampling technique. To start, I created an extremely simple example -- a 1d Gaussian. However, I get incorrect results: It returns log(Z)=-0.32, instead of 0. Could you please help me figure out what I did wrong?
Also, do you have advice on how to build the perturb() function for a given problem? So far, I reused the multi-scale loguniform/Gaussian from SpikeSlab. I am also unsure in which cases not to return 0.

Kind regards,
                       Johannes
