### PR TITLE
Extra command line argument

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -295,6 +295,8 @@ DNest3 Command Line Options:
 -d <filename>: Load data from the specified file, if required.
 -c <value>: Specify a compression value (between levels) other than e.
 -t <num_threads>: run on the specified number of threads. Default=1.
+-f <filename>: a custom configuration file for adding problem specific
+           options if required.
 \end{verbatim}
 \end{framed}
 \end{figure}
@@ -317,6 +319,13 @@ the seed. For example, to execute \dnest~with
 8 threads and a seed of 42, use {\tt ./main -t 8 -s 42}.
 When running with multiple threads, \dnest~uses a separate generator for each
 thread, and ensures that they are seeded with different values.\\
+
+If you have any additional configuration information required by the run, e.g.\
+for setting values needed for a particular model that you don't want to hardcode,
+then they can be added through specifying a configuration file using the {\tt -f}
+option. You will have to write your own function to read in this file, so it can
+be in whatever format you are comfortable with (e.g.\ an {\tt ini} file, or {\tt
+json} file).\\
 
 \section{The OPTIONS file}\label{sec:options}
 Here is an example OPTIONS file.

--- a/include/CommandLineOptions.h
+++ b/include/CommandLineOptions.h
@@ -39,6 +39,7 @@ class CommandLineOptions
 		std::string dataFile;
 		std::string compression;
 		int numThreads;
+		std::string configFile;
 
 	public:
 		CommandLineOptions(int argc, char** argv);
@@ -61,6 +62,9 @@ class CommandLineOptions
 
 		int get_numThreads() const
 		{ return numThreads; }
+
+		const std::string& get_configFile() const
+		{ return configFile; }
 
 		// Convert seed string to an integer and return it
 		unsigned long get_seed_long() const;

--- a/src/CommandLineOptions.cpp
+++ b/src/CommandLineOptions.cpp
@@ -36,6 +36,7 @@ CommandLineOptions::CommandLineOptions(int argc, char** argv)
 ,dataFile("")
 ,compression("2.7182818284590451")
 ,numThreads(1)
+,configFile("")
 {
 	// The following code is based on the example given at
 	// http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html#Example-of-Getopt
@@ -44,7 +45,7 @@ CommandLineOptions::CommandLineOptions(int argc, char** argv)
 	stringstream s;
 
 	opterr = 0;
-	while((c = getopt(argc, argv, "hl:o:s:d:c:t:")) != -1)
+	while((c = getopt(argc, argv, "hl:o:s:d:c:t:f:")) != -1)
 	switch(c)
 	{
 		case 'h':
@@ -68,6 +69,9 @@ CommandLineOptions::CommandLineOptions(int argc, char** argv)
 		case 't':
 			s<<optarg;
 			s>>numThreads;
+			break;
+		case 'f':
+			configFile = string(optarg);
 			break;
 		case '?':
 			cerr<<"# Option "<<optopt<<" requires an argument."<<endl;
@@ -119,6 +123,7 @@ void CommandLineOptions::printHelp() const
 	cout<<"-d <filename>: Load data from the specified file, if required."<<endl;
 	cout<<"-c <value>: Specify a compression value (between levels) other than e."<<endl;
 	cout<<"-t <num_threads>: run on the specified number of threads. Default=1."<<endl;
+	cout<<"-f <filename>: a custom configuration file for adding problem specific options if required."<<endl;
 	exit(0);
 }
 


### PR DESCRIPTION
Hi Brendon,

I have a patch allowing an extra command line argument. The argument (`-f`) allows a filename to be input that the user can then read in as they see fit - this could contain configuration information about the model or likelihood that the user does not wish to hardcode (an example of what I would use this for is shown in https://github.com/mattpitkin/Flake/blob/master/Flares/flake.cpp and https://github.com/mattpitkin/Flake/blob/master/Flares/CustomConfigFile.cpp).

If you think this would be useful to anyone else then would you consider adding it?

Cheers,

Matt