### PR TITLE
Added command line option to gzip the sample.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,16 @@ include_directories (SYSTEM ${GSL_INCLUDES})
 #                                                                      BOOST
 # ==========================================================================
 
-find_package (Boost COMPONENTS thread system)
+find_package (Boost COMPONENTS thread system iostreams)
 if (Boost_FOUND)
     list (APPEND DNEST_DEPS ${Boost_LIBRARIES})
     include_directories (SYSTEM ${Boost_INCLUDES})
+
+    # try and find zlib if available
+    find_package (ZLIB)
+    if (ZLIB_FOUND)
+        add_definitions (-DDNest3_zlib)
+    endif (ZLIB_FOUND)
 else (Boost_FOUND)
     add_definitions (-DDNest3_No_Boost)
 endif (Boost_FOUND)

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -72,7 +72,9 @@ for each of the dependencies. Here's a list of dependencies:\\
 \begin{itemize}
 \item The GNU Scientific Library (GSL)
 \item Python 2, along with the NumPy and matplotlib packages
-\item The {\tt thread} and {\tt system} parts of the Boost C++ library.
+\item The {\tt zlib} library (this is only required if wanting the ability to
+output samples to a {\tt gzipped} file, otherwise it can be excluded)
+\item The {\tt thread}, {\tt system} and {\tt iostreams} parts of the Boost C++ library.
 It may be easier to just install all of Boost.
 \item To compile \dnest, you need {\tt cmake}.\\
 \end{itemize}
@@ -81,7 +83,8 @@ On Ubuntu, I can install these packages with the following commands:
 \begin{verbatim}
 sudo apt-get install libgsl0-dev
 sudo apt-get install python-numpy python-matplotlib
-sudo apt-get install libboost-thread-dev libboost-system-dev
+sudo apt-get install zlib1g-dev
+sudo apt-get install libboost-thread-dev libboost-system-dev libboost-iostreams-dev
 sudo apt-get install cmake
 \end{verbatim}
 
@@ -94,7 +97,8 @@ in the recent C++11 standard, I have not ported \dnest~to C++11 and have no
 intention of doing so in the near future.\\
 
 It is also possible to compile \dnest~without Boost, however this is not
-recommended, and you will not be able to use any of the multi-threaded options.\\
+recommended, and you will not be able to use any of the multi-threaded options
+or the {\tt gzip} option.\\
 
 \subsection{Compiling}
 Please follow the instructions in README.md to compile \dnest~using cmake.
@@ -297,6 +301,7 @@ DNest3 Command Line Options:
 -t <num_threads>: run on the specified number of threads. Default=1.
 -f <filename>: a custom configuration file for adding problem specific
            options if required.
+-z: the output "sample.txt" file will be gzipped and have the suffix ".gz".
 \end{verbatim}
 \end{framed}
 \end{figure}
@@ -319,6 +324,9 @@ the seed. For example, to execute \dnest~with
 8 threads and a seed of 42, use {\tt ./main -t 8 -s 42}.
 When running with multiple threads, \dnest~uses a separate generator for each
 thread, and ensures that they are seeded with different values.\\
+
+The {\tt -z} option is only available is you have compiled with the {\tt zlib}
+library and Boost {\tt iostreams} library installed. \\
 
 If you have any additional configuration information required by the run, e.g.\
 for setting values needed for a particular model that you don't want to hardcode,

--- a/include/CommandLineOptions.h
+++ b/include/CommandLineOptions.h
@@ -40,7 +40,8 @@ class CommandLineOptions
 		std::string compression;
 		int numThreads;
 		std::string configFile;
-
+		bool useGzip;
+                
 	public:
 		CommandLineOptions(int argc, char** argv);
 
@@ -65,6 +66,9 @@ class CommandLineOptions
 
 		const std::string& get_configFile() const
 		{ return configFile; }
+
+		bool set_gzip() const
+		{ return useGzip; }
 
 		// Convert seed string to an integer and return it
 		unsigned long get_seed_long() const;

--- a/include/Options.h
+++ b/include/Options.h
@@ -63,8 +63,12 @@ class Options
 			double beta,
 			int maxNumSamples);
 
-		Options(const char* filename);
+		Options(const char* filename, bool useGzip);
+
 		void load(const char* filename);
+                
+		// function to append ".gz" suffix to sampleFile
+		void set_gzip_sample_file();
 };
 
 } // namespace DNest3

--- a/include/Sampler.h
+++ b/include/Sampler.h
@@ -32,11 +32,11 @@ template<class ModelType>
 class Sampler
 {
 	private:
-		// Options (most useful comment ever)
-		Options options;
-
 		// Target compression value
 		double compression;
+
+                // Options (most useful comment ever)
+		Options options;
 
 		// Stuff pertaining to the particles
 		std::vector<ModelType> particles;

--- a/include/StartImpl.h
+++ b/include/StartImpl.h
@@ -101,7 +101,7 @@ Sampler<ModelType> setup(const CommandLineOptions& options)
 	Options samplerOptions(options.get_optionsFile().c_str());
 
 	// Create sampler
-	Sampler<ModelType> sampler(samplerOptions);
+	Sampler<ModelType> sampler(options.get_compression_double(), samplerOptions);
 
 	// Load levels file if requested
 	if(options.get_levelsFile().compare("") != 0)

--- a/include/StartImpl.h
+++ b/include/StartImpl.h
@@ -55,7 +55,7 @@ MTSampler<ModelType> setup_mt(const CommandLineOptions& options)
 	RandomNumberGenerator::get_instance().set_seed(options.get_seed_long());
 
 	// Load sampler options from file
-	Options samplerOptions(options.get_optionsFile().c_str());
+	Options samplerOptions(options.get_optionsFile().c_str(), options.set_gzip());
 
 	// Create sampler
 	MTSampler<ModelType> sampler(options.get_numThreads(),

--- a/src/CommandLineOptions.cpp
+++ b/src/CommandLineOptions.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 namespace DNest3
 {
-
+  
 CommandLineOptions::CommandLineOptions(int argc, char** argv)
 :levelsFile("")
 ,optionsFile("OPTIONS")
@@ -37,6 +37,7 @@ CommandLineOptions::CommandLineOptions(int argc, char** argv)
 ,compression("2.7182818284590451")
 ,numThreads(1)
 ,configFile("")
+,useGzip(false)
 {
 	// The following code is based on the example given at
 	// http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html#Example-of-Getopt
@@ -45,7 +46,7 @@ CommandLineOptions::CommandLineOptions(int argc, char** argv)
 	stringstream s;
 
 	opterr = 0;
-	while((c = getopt(argc, argv, "hl:o:s:d:c:t:f:")) != -1)
+	while((c = getopt(argc, argv, "hl:o:s:d:c:t:f:z")) != -1)
 	switch(c)
 	{
 		case 'h':
@@ -72,6 +73,9 @@ CommandLineOptions::CommandLineOptions(int argc, char** argv)
 			break;
 		case 'f':
 			configFile = string(optarg);
+			break;
+		case 'z':
+			useGzip = true;
 			break;
 		case '?':
 			cerr<<"# Option "<<optopt<<" requires an argument."<<endl;
@@ -124,7 +128,10 @@ void CommandLineOptions::printHelp() const
 	cout<<"-c <value>: Specify a compression value (between levels) other than e."<<endl;
 	cout<<"-t <num_threads>: run on the specified number of threads. Default=1."<<endl;
 	cout<<"-f <filename>: a custom configuration file for adding problem specific options if required."<<endl;
-	exit(0);
+#ifdef DNest3_zlib
+	cout<<"-z: the output \"sample.txt\" file will be gzipped and have the suffix \".gz\"."<<endl;
+#endif
+        exit(0);
 }
 
 } // namespace DNest3

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -54,12 +54,13 @@ Options::Options(int numParticles,
 		beta >= 0. && maxNumSamples >= 0);
 }
 
-Options::Options(const char* filename)
+Options::Options(const char* filename, bool useGzip)
 :sampleFile("sample.txt")
 ,sampleInfoFile("sample_info.txt")
 ,levelsFile("levels.txt")
 {
 	load(filename);
+	if ( useGzip ){ set_gzip_sample_file(); }
 }
 
 void Options::load(const char* filename)
@@ -89,6 +90,11 @@ void Options::load(const char* filename)
 	assert( numParticles > 0 && newLevelInterval > 0 &&
 	threadSteps > 0 && maxNumLevels > 0 && lambda > 0. &&
 	beta >= 0. && maxNumSamples >= 0);
+}
+
+void Options::set_gzip_sample_file()
+{
+	sampleFile = sampleFile + string(".gz"); 
 }
 
 } // namespace DNest3


### PR DESCRIPTION
In projects with very large numbers of parameters the `sample.txt` file could get pretty large. To help reduce the file size I've allowed the user to specify a new `-z` option, which will instead output samples to a gzipped file - `sample.txt.gz`. This requires [`zlib`](http://www.zlib.net/) to be installed and the Boost iostreams library. I've added checks for these libraries on compilation, so if zlib is not found then the `-z` option won't be allowed and standard functionality used.

In any python postprocessing for reading in the samples `numpy.loadtxt` is fine reading in gzipped file is they have the `.gz` suffix.

This pull request also includes a bug fix that was present in the Sampler class definition when compiling without Boost.